### PR TITLE
Handle quick heading change

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import drawGame from "./drawGame";
+import move from "./move";
 import processInput from "./processInput";
 import processPosition from "./processPosition";
 
@@ -29,6 +30,7 @@ const gameLoop = (state: GameState): void => {
       process.exit();
     }
     let nextState = processInput(state, lastPressed);
+    nextState = move(nextState);
     nextState = processPosition(nextState);
 
     // repeat!
@@ -57,15 +59,6 @@ process.stdin.on("keypress", (str, { ctrl, name }) => {
 
     let keyName: Direction = vimMapping[name];
     if (!keyName) keyName = name;
-
-    if (
-      (lastPressed === "left" && keyName === "right") ||
-      (lastPressed === "right" && keyName === "left") ||
-      (lastPressed === "up" && keyName === "down") ||
-      (lastPressed === "down" && keyName === "up")
-    ) {
-      return;
-    }
 
     lastPressed = keyName;
   }

--- a/src/move.ts
+++ b/src/move.ts
@@ -1,0 +1,40 @@
+const move = (state: GameState): GameState => {
+  switch (state.heading) {
+    case 'right':
+      return {
+        ...state,
+        snake: [
+          [state.snake[0][0] + 1, state.snake[0][1]],
+          ...state.snake.slice(0, -1),
+        ],
+      };
+    case 'left':
+      return {
+        ...state,
+        snake: [
+          [state.snake[0][0] - 1, state.snake[0][1]],
+          ...state.snake.slice(0, -1),
+        ],
+      };
+    case 'up':
+      return {
+        ...state,
+        snake: [
+          [state.snake[0][0], state.snake[0][1] - 1],
+          ...state.snake.slice(0, -1),
+        ],
+      };
+    case 'down':
+      return {
+        ...state,
+        snake: [
+          [state.snake[0][0], state.snake[0][1] + 1],
+          ...state.snake.slice(0, -1),
+        ],
+      };
+    default:
+      return state;
+  }
+};
+
+export default move;

--- a/src/processInput.ts
+++ b/src/processInput.ts
@@ -1,44 +1,17 @@
-const processInput = (state: GameState, key: string): GameState => {
-  switch (key) {
-    case 'right':
-      return {
-        ...state,
-        heading: 'right',
-        snake: [
-          [state.snake[0][0] + 1, state.snake[0][1]],
-          ...state.snake.slice(0, -1),
-        ],
-      };
-    case 'left':
-      return {
-        ...state,
-        heading: 'left',
-        snake: [
-          [state.snake[0][0] - 1, state.snake[0][1]],
-          ...state.snake.slice(0, -1),
-        ],
-      };
-    case 'up':
-      return {
-        ...state,
-        heading: 'up',
-        snake: [
-          [state.snake[0][0], state.snake[0][1] - 1],
-          ...state.snake.slice(0, -1),
-        ],
-      };
-    case 'down':
-      return {
-        ...state,
-        heading: 'down',
-        snake: [
-          [state.snake[0][0], state.snake[0][1] + 1],
-          ...state.snake.slice(0, -1),
-        ],
-      };
-    default:
-      return state;
+const processInput = (state: GameState, desiredHeading: Direction): GameState => {
+  const heading = state.heading;
+  if (
+    (heading === "left" && desiredHeading === "right") ||
+    (heading === "right" && desiredHeading === "left") ||
+    (heading === "up" && desiredHeading === "down") ||
+    (heading === "down" && desiredHeading === "up")
+  ) {
+    return state;
   }
+  return {
+    ...state,
+    heading: desiredHeading
+  };
 };
 
 export default processInput;


### PR DESCRIPTION
Split processInputs into two parts
Handle situation where user quickly turns around, if user managed
to squeeze 2 keystrokes in single frame, it was possible to turn
around in place and lose game

Fix to https://github.com/denvaar/snek/issues/12