### PR TITLE
Fix noise from `aplay` reading a non wav file.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -122,7 +122,7 @@ gameLoop(initialState);
 const backgroundSound = soundService.playBackgroundSound();
 
 process.on('exit', () => {
-  backgroundSound.kill();
+  if (backgroundSound) backgroundSound.kill();
   process.stdout.write('\x1b[?25h');
 });
 

--- a/src/soundService.ts
+++ b/src/soundService.ts
@@ -23,13 +23,19 @@ export default class SoundService {
     this.play('impact.wav');
   }
 
-  public playBackgroundSound(): ChildProcess {
+  public playBackgroundSound(): ChildProcess | null {
     return this.play('background.mp3');
   }
 
-  private play(soundName: string): ChildProcess {
-    return player.play(`${SoundService.soundsPath}${soundName}`, (err: Error): void => {
-      if (err) throw err;
-    });
+  private play(soundName: string): ChildProcess | null {
+    var isWav: boolean = !!soundName.match(/\.wav/);
+    if (!isWav && player.player == 'aplay') {
+      console.error("Warning: aplay can't play non raw wav format.");
+      return null;
+    } else {
+      return player.play(`${SoundService.soundsPath}${soundName}`, (err: Error): void => {
+        if (err) throw err;
+      });
+    }
   }
 }

--- a/src/soundService.ts
+++ b/src/soundService.ts
@@ -28,7 +28,7 @@ export default class SoundService {
   }
 
   private play(soundName: string): ChildProcess | null {
-    var isWav: boolean = !!soundName.match(/\.wav/);
+    var isWav: boolean = !!soundName.match(/\.wav$/);
     if (!isWav && player.player == 'aplay') {
       console.error("Warning: aplay can't play non raw wav format.");
       return null;


### PR DESCRIPTION
The `aplay` player do not support non raw audio files, so it is playing noise from `background.mp3`.
This patch test the file type and the player before run `player.play()`.